### PR TITLE
[fix] 새 사용자 가입시, 닉네임에 랜덤 숫자 추가 (#4)

### DIFF
--- a/Gathering_be/src/main/java/com/Gathering_be/service/AuthService.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/service/AuthService.java
@@ -93,10 +93,6 @@ public class AuthService {
     }
 
     private String generateUniqueNickname(String baseName) {
-        if (!profileRepository.existsByNickname(baseName)) {
-            return baseName;
-        }
-
         while (true) {
             int randomNumber = (int) (Math.random() * 900000) + 100000;
             String nickname = baseName + "#" + randomNumber;


### PR DESCRIPTION
- 사용자 가입시, 자동 닉네임 설정
    - (이전) 사용자 이름 그대로 ex)최보근
    - (이후) 사용자 이름 + #랜덤숫자 ex)최보근#123456