### PR TITLE
[fix] 이메일 인증, 회원가입 로직 변경 (#19)

### DIFF
--- a/Gathering_be/src/main/java/com/Gathering_be/controller/AuthController.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/controller/AuthController.java
@@ -39,14 +39,8 @@ public class AuthController {
 
     @PostMapping("/signup")
     public ResponseEntity<ResultResponse> signUp(@Valid @RequestBody SignUpRequest request) {
-        authService.verifyCodeAndSignUp(request);
+        authService.signUp(request);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.SIGNUP_SUCCESS));
-    }
-
-    @PostMapping("/verify/send")
-    public ResponseEntity<ResultResponse> sendVerification(@RequestParam String email) {
-        emailVerificationService.sendVerificationCode(email);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.EMAIL_SENT_SUCCESS));
     }
 
     @PostMapping("/login")

--- a/Gathering_be/src/main/java/com/Gathering_be/controller/EmailVerificationController.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/controller/EmailVerificationController.java
@@ -1,0 +1,30 @@
+package com.Gathering_be.controller;
+
+import com.Gathering_be.global.response.ResultCode;
+import com.Gathering_be.global.response.ResultResponse;
+import com.Gathering_be.service.EmailVerificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/verify")
+@RequiredArgsConstructor
+public class EmailVerificationController {
+    private final EmailVerificationService emailVerificationService;
+
+    @PostMapping("/send")
+    public ResponseEntity<ResultResponse> sendVerification(@RequestParam String email) {
+        emailVerificationService.sendVerificationCode(email);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.EMAIL_SENT_SUCCESS));
+    }
+
+    @PostMapping("/code")
+    public ResponseEntity<ResultResponse> verifyCode(@RequestParam String email, @RequestParam String code) {
+        emailVerificationService.verifyCode(email, code);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.EMAIL_VERIFY_SUCCESS));
+    }
+}

--- a/Gathering_be/src/main/java/com/Gathering_be/exception/EmailNotVerified.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/exception/EmailNotVerified.java
@@ -1,0 +1,8 @@
+package com.Gathering_be.exception;
+
+import com.Gathering_be.global.exception.BusinessException;
+import com.Gathering_be.global.exception.ErrorCode;
+
+public class EmailNotVerified extends BusinessException {
+    public EmailNotVerified() { super(ErrorCode.EMAIL_NOT_VERIFIED); }
+}

--- a/Gathering_be/src/main/java/com/Gathering_be/global/config/SecurityConfig.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/global/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
 
     private static final String[] PERMITTED_API_URL = {
             "/api/auth/**",
+            "/api/verify/**",
             "/actuator/prometheus"
     };
 

--- a/Gathering_be/src/main/java/com/Gathering_be/global/exception/ErrorCode.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     SOCIAL_MEMBER_LOGIN(400, "AU006", "소셜 로그인으로 가입된 계정입니다. 해당 소셜 로그인을 이용해주세요."),
     UNAUTHORIZED_ACCESS(403, "AU007", "해당 리소스에 대한 접근 권한이 없습니다."),
     INVALID_VERIFICATION_CODE(400, "AU008", "올바르지 않은 인증 코드입니다."),
+    EMAIL_NOT_VERIFIED(400, "AU009", "이메일 인증이 완료되지 않았습니다."),
 
     // Member
     MEMBER_NOT_FOUND(404, "M001", "존재하지 않는 유저입니다."),

--- a/Gathering_be/src/main/java/com/Gathering_be/global/response/ResultCode.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/global/response/ResultCode.java
@@ -14,6 +14,7 @@ public enum ResultCode {
     TOKEN_REISSUED_SUCCESS(200, "AU005", "토큰 재발급에 성공하였습니다."),
     LOGOUT_SUCCESS(200, "AU006", "로그아웃에 성공하였습니다."),
     EMAIL_SENT_SUCCESS(200, "AU007", "이메일로 인증코드 전송을 성공하였습니다."),
+    EMAIL_VERIFY_SUCCESS(200, "AU008", "이메일 인증코드 인증을 성공하였습니다."),
 
     //Profile
     PROFILE_READ_SUCCESS(200, "P001", "프로필 조회에 성공하였습니다."),


### PR DESCRIPTION
[fix] 이메일 인증, 회원가입 로직 변경 (#19)

회원가입 로직
1. POST /api/verify/send 
   - input : 이메일
   - 이메일로 코드를 보냄
2. POST /api/verify/code 
   - input: 이메일, 코드
   - 이메일, 코드로 검증
3. POST /api/auth/signup
   - input: 이메일, 코드, 이름, 비밀번호
   - 회원가입