### PR TITLE
Be/feat/admin

### DIFF
--- a/Gathering_be/src/main/java/com/Gathering_be/controller/AdminController.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/controller/AdminController.java
@@ -1,0 +1,58 @@
+package com.Gathering_be.controller;
+
+import com.Gathering_be.dto.request.RoleUpdateRequest;
+import com.Gathering_be.dto.response.MemberInfoForAdminResponse;
+import com.Gathering_be.dto.response.ProjectSimpleResponse;
+import com.Gathering_be.global.enums.SearchType;
+import com.Gathering_be.global.response.ResultCode;
+import com.Gathering_be.global.response.ResultResponse;
+import com.Gathering_be.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+    private final AdminService adminService;
+
+    @GetMapping("/members")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ResultResponse> findMembers(@RequestParam(required = false) String keyword,
+                                                      @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<MemberInfoForAdminResponse> members = adminService.findMembers(keyword, pageable);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.MEMBER_READ_SUCCESS, members));
+    }
+
+    @PatchMapping("/members/{memberId}/role")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ResultResponse> changeMemberRole(@PathVariable Long memberId, @RequestBody RoleUpdateRequest request) {
+        adminService.changeMemberRole(memberId, request.getNewRole());
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.MEMBER_ROLE_CHANGE_SUCCESS));
+    }
+
+    @GetMapping("/project/pagination")
+    public ResponseEntity<ResultResponse> getAllProjects(@RequestParam(defaultValue = "1") int page,
+                                                         @RequestParam(defaultValue = "-createdAt") String sort,
+                                                         @RequestParam(defaultValue = "ALL") String position,
+                                                         @RequestParam(required = false) String techStack,
+                                                         @RequestParam(defaultValue = "ALL") String type,
+                                                         @RequestParam(defaultValue = "ALL") String mode,
+                                                         @RequestParam(required = false) Boolean isClosed,
+                                                         @RequestParam(required = false) SearchType searchType,
+                                                         @RequestParam(required = false) String keyword
+    ) {
+        Page<ProjectSimpleResponse> projects = adminService.searchProjectsWithFilters(
+                page, 18, sort, position, techStack, type, mode, isClosed, searchType, keyword
+        );
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_READ_SUCCESS, projects));
+    }
+
+
+}

--- a/Gathering_be/src/main/java/com/Gathering_be/controller/AdminController.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/controller/AdminController.java
@@ -2,7 +2,7 @@ package com.Gathering_be.controller;
 
 import com.Gathering_be.dto.request.RoleUpdateRequest;
 import com.Gathering_be.dto.response.MemberInfoForAdminResponse;
-import com.Gathering_be.dto.response.ProjectSimpleResponse;
+import com.Gathering_be.dto.response.ProjectResponseForAdmin;
 import com.Gathering_be.global.enums.SearchType;
 import com.Gathering_be.global.response.ResultCode;
 import com.Gathering_be.global.response.ResultResponse;
@@ -38,6 +38,7 @@ public class AdminController {
     }
 
     @GetMapping("/project/pagination")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ResultResponse> getAllProjects(@RequestParam(defaultValue = "1") int page,
                                                          @RequestParam(defaultValue = "-createdAt") String sort,
                                                          @RequestParam(defaultValue = "ALL") String position,
@@ -45,14 +46,21 @@ public class AdminController {
                                                          @RequestParam(defaultValue = "ALL") String type,
                                                          @RequestParam(defaultValue = "ALL") String mode,
                                                          @RequestParam(required = false) Boolean isClosed,
+                                                         @RequestParam(required = false) Boolean isDeleted,
                                                          @RequestParam(required = false) SearchType searchType,
                                                          @RequestParam(required = false) String keyword
     ) {
-        Page<ProjectSimpleResponse> projects = adminService.searchProjectsWithFilters(
-                page, 18, sort, position, techStack, type, mode, isClosed, searchType, keyword
+        Page<ProjectResponseForAdmin> projects = adminService.searchProjectsWithFilters(
+                page, 18, sort, position, techStack, type, mode, isClosed, isDeleted, searchType, keyword
         );
         return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_READ_SUCCESS, projects));
     }
 
+    @DeleteMapping("/project/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ResultResponse> deleteProject(@PathVariable Long id) {
+        adminService.deleteProject(id);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_DELETE_SUCCESS));
+    }
 
 }

--- a/Gathering_be/src/main/java/com/Gathering_be/controller/AdminController.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/controller/AdminController.java
@@ -24,10 +24,8 @@ public class AdminController {
 
     @GetMapping("/members")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<ResultResponse> findMembers(@RequestParam(required = false) String keyword,
-                                                      @PageableDefault(size = 10) Pageable pageable
-    ) {
-        Page<MemberInfoForAdminResponse> members = adminService.findMembers(keyword, pageable);
+    public ResponseEntity<ResultResponse> findMembers(@PageableDefault(size = 10) Pageable pageable) {
+        Page<MemberInfoForAdminResponse> members = adminService.findMembers(pageable);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.MEMBER_READ_SUCCESS, members));
     }
 

--- a/Gathering_be/src/main/java/com/Gathering_be/controller/AdminController.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.Gathering_be.controller;
 
 import com.Gathering_be.dto.request.RoleUpdateRequest;
+import com.Gathering_be.dto.response.MemberCountForAdminResponse;
 import com.Gathering_be.dto.response.MemberInfoForAdminResponse;
 import com.Gathering_be.dto.response.ProjectResponseForAdmin;
 import com.Gathering_be.global.enums.SearchType;
@@ -61,6 +62,13 @@ public class AdminController {
     public ResponseEntity<ResultResponse> deleteProject(@PathVariable Long id) {
         adminService.deleteProject(id);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_DELETE_SUCCESS));
+    }
+
+    @GetMapping("/members/count")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ResultResponse> getMemberCount() {
+        long count = adminService.getMemberCount();
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.MEMBER_COUNT_READ_SUCCESS, MemberCountForAdminResponse.from(count)));
     }
 
 }

--- a/Gathering_be/src/main/java/com/Gathering_be/domain/Member.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/domain/Member.java
@@ -47,4 +47,8 @@ public class Member extends BaseTimeEntity {
         this.provider = OAuthProvider.BASIC;
         this.role = Role.ROLE_USER;
     }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
 }

--- a/Gathering_be/src/main/java/com/Gathering_be/dto/request/RoleUpdateRequest.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/dto/request/RoleUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.Gathering_be.dto.request;
+
+import com.Gathering_be.global.enums.Role;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RoleUpdateRequest {
+    private Role newRole;
+}

--- a/Gathering_be/src/main/java/com/Gathering_be/dto/response/MemberCountForAdminResponse.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/dto/response/MemberCountForAdminResponse.java
@@ -1,0 +1,14 @@
+package com.Gathering_be.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberCountForAdminResponse {
+    private final long totalMemberCount;
+
+    public static MemberCountForAdminResponse from(long count) {
+        return new MemberCountForAdminResponse(count);
+    }
+}

--- a/Gathering_be/src/main/java/com/Gathering_be/dto/response/MemberInfoForAdminResponse.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/dto/response/MemberInfoForAdminResponse.java
@@ -1,0 +1,39 @@
+package com.Gathering_be.dto.response;
+
+import com.Gathering_be.domain.Member;
+import com.Gathering_be.domain.Profile;
+import com.Gathering_be.global.enums.Role;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MemberInfoForAdminResponse {
+    private Long memberId;
+    private String email;
+    private String memberName;
+    private String nickname;
+    private Role role;
+    private LocalDateTime createdAt;
+
+    public static MemberInfoForAdminResponse from(Profile profile) {
+        Member member = profile.getMember();
+        return new MemberInfoForAdminResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getName(),
+                profile.getNickname(),
+                member.getRole(),
+                member.getCreatedAt()
+        );
+    }
+
+    private MemberInfoForAdminResponse(Long memberId, String email, String memberName, String nickname, Role role, LocalDateTime createdAt) {
+        this.memberId = memberId;
+        this.email = email;
+        this.memberName = memberName;
+        this.nickname = nickname;
+        this.role = role;
+        this.createdAt = createdAt;
+    }
+}

--- a/Gathering_be/src/main/java/com/Gathering_be/dto/response/ProjectResponseForAdmin.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/dto/response/ProjectResponseForAdmin.java
@@ -1,0 +1,77 @@
+package com.Gathering_be.dto.response;
+
+import com.Gathering_be.domain.Project;
+import com.Gathering_be.global.enums.ApplyStatus;
+import com.Gathering_be.global.enums.JobPosition;
+import com.Gathering_be.global.enums.ProjectType;
+import com.Gathering_be.global.enums.TechStack;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+public class ProjectResponseForAdmin {
+    private Long projectId;
+    private ProjectType projectType;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deadline;
+
+    private String title;
+    private String authorNickname;
+    private String profileColor;
+
+    private List<JobPosition> requiredPositions;
+    private Set<TechStack> techStacks;
+    private boolean isClosed;
+    private boolean isInterested;
+    private Long viewCount;
+
+    private ApplyStatus applyStatus;
+    private boolean isDeleted;
+
+    @Builder
+    public ProjectResponseForAdmin(Long projectId, ProjectType projectType, LocalDateTime createdAt, LocalDateTime updatedAt,
+                                 LocalDateTime deadline, String title, String authorNickname, String profileColor,
+                                 List<JobPosition> requiredPositions, Set<TechStack> techStacks, boolean isClosed,
+                                 boolean isInterested, Long viewCount, ApplyStatus applyStatus, boolean isDeleted) {
+        this.projectId = projectId;
+        this.projectType = projectType;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deadline = deadline;
+        this.title = title;
+        this.authorNickname = authorNickname;
+        this.requiredPositions = requiredPositions;
+        this.techStacks = techStacks;
+        this.isClosed = isClosed;
+        this.isInterested = isInterested;
+        this.viewCount = viewCount;
+        this.applyStatus = applyStatus;
+        this.profileColor = profileColor;
+        this.isDeleted = isDeleted;
+    }
+
+    public static ProjectResponseForAdmin from(Project project, boolean isInterested, ApplyStatus applyStatus) {
+        return ProjectResponseForAdmin.builder()
+                .projectId(project.getId())
+                .projectType(project.getProjectType())
+                .createdAt(project.getCreatedAt())
+                .updatedAt(project.getUpdatedAt())
+                .deadline(project.getDeadline())
+                .title(project.getTitle())
+                .authorNickname(project.getProfile().getNickname())
+                .profileColor(project.getProfile().getProfileColor())
+                .requiredPositions(project.getRequiredPositions())
+                .techStacks(project.getTechStacks())
+                .isClosed(project.isClosed())
+                .isInterested(isInterested)
+                .viewCount(project.getViewCount())
+                .applyStatus(applyStatus)
+                .isDeleted(project.isDeleted())
+                .build();
+    }
+}

--- a/Gathering_be/src/main/java/com/Gathering_be/global/config/SecurityConfig.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/global/config/SecurityConfig.java
@@ -74,6 +74,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorizeRequest ->
                         authorizeRequest
+                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
                                 .requestMatchers(PERMITTED_API_URL).permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/Gathering_be/src/main/java/com/Gathering_be/global/response/ResultCode.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/global/response/ResultCode.java
@@ -45,6 +45,7 @@ public enum ResultCode {
     // Admin
     MEMBER_READ_SUCCESS(200, "AD001", "멤버 목록 호출 성공"),
     MEMBER_ROLE_CHANGE_SUCCESS(200, "AD001", "멤버 ROLE 전환 성공"),
+    MEMBER_COUNT_READ_SUCCESS(200, "AD003", "멤버 카운트 호출 성공"),
     ;
 
     private final int status;

--- a/Gathering_be/src/main/java/com/Gathering_be/global/response/ResultCode.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/global/response/ResultCode.java
@@ -41,6 +41,10 @@ public enum ResultCode {
     APPLICATION_READ_SUCCESS(200, "AP002", "지원서 조회에 성공하였습니다."),
     APPLICATION_DELETE_SUCCESS(200, "AP003", "지원서 삭제에 성공하였습니다."),
     APPLICATION_STATUS_UPDATED(200, "AP004", "지원자의 지원서 상태를 변경하였습니다."),
+
+    // Admin
+    MEMBER_READ_SUCCESS(200, "AD001", "멤버 목록 호출 성공"),
+    MEMBER_ROLE_CHANGE_SUCCESS(200, "AD001", "멤버 ROLE 전환 성공"),
     ;
 
     private final int status;

--- a/Gathering_be/src/main/java/com/Gathering_be/repository/ProfileRepository.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/repository/ProfileRepository.java
@@ -18,7 +18,7 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
     Optional<Profile> findByNickname(String nickname);
     boolean existsByNickname(String nickname);
     List<Profile> findAllByNicknameIn(Set<String> nicknames);
-    @Query("SELECT p FROM Profile p JOIN p.member m WHERE " +
-            "(:keyword IS NULL OR p.nickname LIKE %:keyword% OR m.email LIKE %:keyword%)")
-    Page<Profile> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
+    @Query(value = "SELECT p FROM Profile p JOIN FETCH p.member m",
+            countQuery = "SELECT COUNT(p) FROM Profile p")
+    Page<Profile> findAllWithMember(Pageable pageable);
 }

--- a/Gathering_be/src/main/java/com/Gathering_be/repository/ProfileRepository.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/repository/ProfileRepository.java
@@ -1,7 +1,11 @@
 package com.Gathering_be.repository;
 
 import com.Gathering_be.domain.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,4 +18,7 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
     Optional<Profile> findByNickname(String nickname);
     boolean existsByNickname(String nickname);
     List<Profile> findAllByNicknameIn(Set<String> nicknames);
+    @Query("SELECT p FROM Profile p JOIN p.member m WHERE " +
+            "(:keyword IS NULL OR p.nickname LIKE %:keyword% OR m.email LIKE %:keyword%)")
+    Page<Profile> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/Gathering_be/src/main/java/com/Gathering_be/repository/custom/ProjectRepositoryCustom.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/repository/custom/ProjectRepositoryCustom.java
@@ -11,4 +11,7 @@ public interface ProjectRepositoryCustom {
     Page<Project> searchProjectsWithFilters(Pageable pageable, JobPosition position, List<TechStack> techStacks,
                                             ProjectType type, ProjectMode mode, Boolean isClosed,
                                             SearchType searchType, String keyword);
+    Page<Project> searchProjectsForAdmin(Pageable pageable, JobPosition position, List<TechStack> techStacks,
+                                            ProjectType type, ProjectMode mode, Boolean isClosed, Boolean isDeleted,
+                                            SearchType searchType, String keyword);
 }

--- a/Gathering_be/src/main/java/com/Gathering_be/repository/custom/ProjectRepositoryImpl.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/repository/custom/ProjectRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.Gathering_be.global.enums.*;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -30,34 +31,48 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
         this.queryFactory = new JPAQueryFactory(entityManager);
     }
 
+    // --- 1. 기존 사용자용 검색 메서드 ---
+    // 이제 내부 헬퍼 메서드를 호출하는 역할만 합니다.
     @Override
-    public Page<Project> searchProjectsWithFilters(Pageable pageable,
-                                                   JobPosition position,
-                                                   List<TechStack> techStacks,
-                                                   ProjectType type,
-                                                   ProjectMode mode,
-                                                   Boolean isClosed,
-                                                   SearchType searchType,
-                                                   String keyword) {
+    public Page<Project> searchProjectsWithFilters(Pageable pageable, JobPosition position, List<TechStack> techStacks, ProjectType type, ProjectMode mode, Boolean isClosed, SearchType searchType, String keyword) {
+        // 공통 로직을 호출하여 조건절 생성
+        BooleanBuilder builder = createCommonWhereBuilder(position, techStacks, type, mode, isClosed, searchType, keyword);
+
+        // 쿼리 실행 로직 호출
+        return executeQuery(builder, pageable);
+    }
+
+    // --- 2. [추가] 관리자용 검색 메서드 ---
+    @Override
+    public Page<Project> searchProjectsForAdmin(Pageable pageable, JobPosition position, List<TechStack> techStacks, ProjectType type, ProjectMode mode, Boolean isClosed, Boolean isDeleted, SearchType searchType, String keyword) {
+        // 공통 로직을 호출하여 기본 조건절 생성
+        BooleanBuilder builder = createCommonWhereBuilder(position, techStacks, type, mode, isClosed, searchType, keyword);
+
+        // 관리자 전용 조건(isDeleted)을 추가
+        if (isDeleted != null) {
+            builder.and(project.isDeleted.eq(isDeleted));
+        }
+
+        // 쿼리 실행 로직 호출
+        return executeQuery(builder, pageable);
+    }
+
+    // --- 3. [리팩토링] 공통 로직을 담당하는 private 헬퍼 메서드 ---
+    private BooleanBuilder createCommonWhereBuilder(JobPosition position, List<TechStack> techStacks, ProjectType type, ProjectMode mode, Boolean isClosed, SearchType searchType, String keyword) {
         BooleanBuilder builder = new BooleanBuilder();
 
-        if (searchType!= null && keyword != null && !keyword.isEmpty()) {
+        // keyword 검색 조건
+        if (searchType != null && keyword != null && !keyword.isEmpty()) {
             switch (searchType) {
-                case TITLE:
-                    builder.and(project.title.containsIgnoreCase(keyword));
-                    break;
-                case CONTENT:
-                    builder.and(project.description.containsIgnoreCase(keyword));
-                    break;
-                case TITLE_CONTENT:
-                    builder.and(project.title.containsIgnoreCase(keyword)
-                            .or(project.description.containsIgnoreCase(keyword)));
-                    break;
-                default:
-                    throw new InvalidSearchTypeException();
+                case TITLE -> builder.and(project.title.containsIgnoreCase(keyword));
+                case CONTENT -> builder.and(project.description.containsIgnoreCase(keyword));
+                case TITLE_CONTENT -> builder.and(project.title.containsIgnoreCase(keyword)
+                        .or(project.description.containsIgnoreCase(keyword)));
+                default -> throw new InvalidSearchTypeException();
             }
         }
 
+        // techStacks 검색 조건
         if (techStacks != null && !techStacks.isEmpty()) {
             BooleanBuilder techStackBuilder = new BooleanBuilder();
             for (TechStack tech : techStacks) {
@@ -66,28 +81,41 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
             builder.and(techStackBuilder);
         }
 
-        if (position != null && !position.equals("ALL")) {
+        // 기타 enum 조건
+        if (position != null) {
             builder.and(project.requiredPositions.contains(position));
         }
-        if (type != null && !type.equals("ALL")) {
+        if (type != null) {
             builder.and(project.projectType.eq(type));
         }
-        if (mode != null && !mode.equals("ALL")) {
+        if (mode != null) {
             builder.and(project.projectMode.eq(mode));
         }
         if (isClosed != null) {
             builder.and(project.isClosed.eq(isClosed));
         }
 
-        QueryResults<Project> results = queryFactory
+        return builder;
+    }
+
+    // --- 4. [리팩토링] 쿼리 실행 로직을 담당하는 private 헬퍼 메서드 ---
+    private Page<Project> executeQuery(BooleanBuilder builder, Pageable pageable) {
+        JPAQuery<Project> query = queryFactory
                 .selectFrom(project)
                 .where(builder)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(getOrderSpecifier(pageable))
-                .fetchResults();
+                .orderBy(getOrderSpecifier(pageable)); // 정렬 조건 적용
 
-        return new PageImpl<>(results.getResults(), pageable, results.getTotal());
+        List<Project> content = query.fetch();
+
+        // Count 쿼리 최적화
+        JPAQuery<Long> countQuery = queryFactory
+                .select(project.count())
+                .from(project)
+                .where(builder);
+
+        return new PageImpl<>(content, pageable, countQuery.fetchOne());
     }
 
     private OrderSpecifier<?> getOrderSpecifier(Pageable pageable) {
@@ -100,5 +128,4 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
             }
         }
         return project.createdAt.desc();
-    }
 }

--- a/Gathering_be/src/main/java/com/Gathering_be/repository/custom/ProjectRepositoryImpl.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/repository/custom/ProjectRepositoryImpl.java
@@ -5,7 +5,6 @@ import com.Gathering_be.domain.QProject;
 import com.Gathering_be.exception.InvalidSearchTypeException;
 import com.Gathering_be.global.enums.*;
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -32,19 +31,22 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
     }
 
     // --- 1. 기존 사용자용 검색 메서드 ---
-    // 이제 내부 헬퍼 메서드를 호출하는 역할만 합니다.
     @Override
-    public Page<Project> searchProjectsWithFilters(Pageable pageable, JobPosition position, List<TechStack> techStacks, ProjectType type, ProjectMode mode, Boolean isClosed, SearchType searchType, String keyword) {
-        // 공통 로직을 호출하여 조건절 생성
+    public Page<Project> searchProjectsWithFilters(Pageable pageable, JobPosition position, List<TechStack> techStacks,
+                                                   ProjectType type, ProjectMode mode, Boolean isClosed,
+                                                   SearchType searchType, String keyword) {
+        // 공통 로직을 호출하여 기본 조건절 생성
         BooleanBuilder builder = createCommonWhereBuilder(position, techStacks, type, mode, isClosed, searchType, keyword);
 
         // 쿼리 실행 로직 호출
         return executeQuery(builder, pageable);
     }
 
-    // --- 2. [추가] 관리자용 검색 메서드 ---
+    // --- 2. 관리자용 검색 메서드 ---
     @Override
-    public Page<Project> searchProjectsForAdmin(Pageable pageable, JobPosition position, List<TechStack> techStacks, ProjectType type, ProjectMode mode, Boolean isClosed, Boolean isDeleted, SearchType searchType, String keyword) {
+    public Page<Project> searchProjectsForAdmin(Pageable pageable, JobPosition position, List<TechStack> techStacks,
+                                                ProjectType type, ProjectMode mode, Boolean isClosed, Boolean isDeleted,
+                                                SearchType searchType, String keyword) {
         // 공통 로직을 호출하여 기본 조건절 생성
         BooleanBuilder builder = createCommonWhereBuilder(position, techStacks, type, mode, isClosed, searchType, keyword);
 
@@ -57,8 +59,10 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
         return executeQuery(builder, pageable);
     }
 
-    // --- 3. [리팩토링] 공통 로직을 담당하는 private 헬퍼 메서드 ---
-    private BooleanBuilder createCommonWhereBuilder(JobPosition position, List<TechStack> techStacks, ProjectType type, ProjectMode mode, Boolean isClosed, SearchType searchType, String keyword) {
+    // --- 3. 공통 로직을 담당하는 private 헬퍼 메서드 ---
+    private BooleanBuilder createCommonWhereBuilder(JobPosition position, List<TechStack> techStacks, ProjectType type,
+                                                    ProjectMode mode, Boolean isClosed,
+                                                    SearchType searchType, String keyword) {
         BooleanBuilder builder = new BooleanBuilder();
 
         // keyword 검색 조건
@@ -98,7 +102,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
         return builder;
     }
 
-    // --- 4. [리팩토링] 쿼리 실행 로직을 담당하는 private 헬퍼 메서드 ---
+    // --- 4. 쿼리 실행 로직을 담당하는 private 헬퍼 메서드 ---
     private Page<Project> executeQuery(BooleanBuilder builder, Pageable pageable) {
         JPAQuery<Project> query = queryFactory
                 .selectFrom(project)
@@ -118,6 +122,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
         return new PageImpl<>(content, pageable, countQuery.fetchOne());
     }
 
+    // 단일 정렬
     private OrderSpecifier<?> getOrderSpecifier(Pageable pageable) {
         for (Sort.Order order : pageable.getSort()) {
             switch (order.getProperty()) {
@@ -128,4 +133,5 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
             }
         }
         return project.createdAt.desc();
+    }
 }

--- a/Gathering_be/src/main/java/com/Gathering_be/service/AdminInitializer.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/service/AdminInitializer.java
@@ -1,0 +1,53 @@
+package com.Gathering_be.service;
+
+import com.Gathering_be.domain.Member;
+import com.Gathering_be.global.enums.Role;
+import com.Gathering_be.repository.MemberRepository;
+import com.Gathering_be.repository.ProfileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile({"dev", "local"})
+@RequiredArgsConstructor
+public class AdminInitializer implements ApplicationRunner {
+    private final MemberRepository memberRepository;
+    private final ProfileRepository profileRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        String adminEmail = "admin@gathering.com";
+        String adminPassword = "admin";
+        String adminNickname = "admin";
+
+        if (memberRepository.findByEmail(adminEmail).isEmpty()) {
+            Member adminMember = Member.localBuilder()
+                    .email(adminEmail)
+                    .name("관리자")
+                    .password(passwordEncoder.encode(adminPassword))
+                    .build();
+            adminMember.updateRole(Role.ROLE_ADMIN);
+            Member savedAdminMember = memberRepository.save(adminMember);
+
+            com.Gathering_be.domain.Profile adminProfile = com.Gathering_be.domain.Profile.builder()
+                    .member(savedAdminMember)
+                    .nickname(adminNickname)
+                    .introduction("서비스 관리자입니다.")
+                    .isPublic(true)
+                    .build();
+            profileRepository.save(adminProfile);
+
+            log.info(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+            log.info("개발용 관리자 계정 및 프로필이 생성되었습니다.");
+            log.info("Email: {}, Password: {}, Nickname: {}", adminEmail, adminPassword, adminNickname);
+            log.info(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+        }
+    }
+}

--- a/Gathering_be/src/main/java/com/Gathering_be/service/AdminService.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/service/AdminService.java
@@ -80,7 +80,11 @@ public class AdminService {
 
         project.getProfile().removeProject(project.isClosed());
         project.delete();
+    }
 
+    @Transactional(readOnly = true)
+    public long getMemberCount() {
+        return memberRepository.count();
     }
 
     private Project getProjectByIdForUpdate(Long projectId) {

--- a/Gathering_be/src/main/java/com/Gathering_be/service/AdminService.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/service/AdminService.java
@@ -32,8 +32,8 @@ public class AdminService {
     private final ProfileRepository profileRepository;
     private final ProjectRepository projectRepository;
 
-    public Page<MemberInfoForAdminResponse> findMembers(String keyword, Pageable pageable) {
-        Page<Profile> profiles = profileRepository.findByKeyword(keyword, pageable);
+    public Page<MemberInfoForAdminResponse> findMembers(Pageable pageable) {
+        Page<Profile> profiles = profileRepository.findAllWithMember(pageable);
         return profiles.map(MemberInfoForAdminResponse::from);
     }
 

--- a/Gathering_be/src/main/java/com/Gathering_be/service/AdminService.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/service/AdminService.java
@@ -1,0 +1,93 @@
+package com.Gathering_be.service;
+
+import com.Gathering_be.domain.Member;
+import com.Gathering_be.domain.Profile;
+import com.Gathering_be.domain.Project;
+import com.Gathering_be.dto.response.MemberInfoForAdminResponse;
+import com.Gathering_be.dto.response.ProjectSimpleResponse;
+import com.Gathering_be.exception.InvalidEnumValue;
+import com.Gathering_be.exception.InvalidSortTypeException;
+import com.Gathering_be.exception.MemberNotFoundException;
+import com.Gathering_be.global.enums.*;
+import com.Gathering_be.repository.MemberRepository;
+import com.Gathering_be.repository.ProfileRepository;
+import com.Gathering_be.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+    private final MemberRepository memberRepository;
+    private final ProfileRepository profileRepository;
+    private final ProjectRepository projectRepository;
+
+    public Page<MemberInfoForAdminResponse> findMembers(String keyword, Pageable pageable) {
+        Page<Profile> profiles = profileRepository.findByKeyword(keyword, pageable);
+        return profiles.map(MemberInfoForAdminResponse::from);
+    }
+
+    public void changeMemberRole(Long memberId, Role newRole) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        member.updateRole(newRole);
+    }
+
+    public Page<ProjectSimpleResponse> searchProjectsWithFilters(int page, int size, String sort, String position,
+                                                                 String techStack, String type, String mode, Boolean isClosed,
+                                                                 SearchType searchType, String keyword) {
+        /* 순수한 ProjectSimpleResponse 보다는
+            Admin 전용 response를 만들어서
+            isDeleted 표시도 함께 제공해야 한다
+            또한, 탐색할 때 isDeleted 된것도 같이 찾아와야 함
+        * */
+        Sort sortCondition = switch (sort) {
+            case "-createdAt" -> Sort.by(Sort.Order.desc("createdAt"));
+            case "createdAt" -> Sort.by(Sort.Order.asc("createdAt"));
+            case "viewCount" -> Sort.by(Sort.Order.desc("viewCount"));
+            default -> throw new InvalidSortTypeException();
+        };
+
+        Pageable pageable = PageRequest.of(page - 1, size,sortCondition);
+
+        JobPosition positionEnum = parseEnum(JobPosition.class, position);
+        ProjectType typeEnum = parseEnum(ProjectType.class, type);
+        ProjectMode modeEnum = parseEnum(ProjectMode.class, mode);
+        List<TechStack> techStacks = (techStack != null && !techStack.isEmpty())
+                ? Arrays.stream(techStack.split(",")).map(TechStack::valueOf).collect(Collectors.toList())
+                : null;
+
+        Page<Project> projectPage = projectRepository.searchProjectsWithFilters(
+                pageable, positionEnum, techStacks, typeEnum, modeEnum, isClosed, searchType, keyword
+        );
+
+        return projectPage
+                .map(project -> ProjectSimpleResponse.from(project, false, null));
+    }
+
+    @Transactional
+    public void deleteProject(Long projectId) {
+        ////
+
+    }
+
+    private <E extends Enum<E>> E parseEnum(Class<E> enumClass, String value) {
+        if (value == null || "ALL".equalsIgnoreCase(value)) {
+            return null;
+        }
+        try {
+            return Enum.valueOf(enumClass, value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidEnumValue();
+        }
+    }
+}


### PR DESCRIPTION
[feat] 관리자 기능 추가
 - admin 전용 API 및 기능을 구현 
 - 이 기능은 일반 사용자에게는 노출되지 않으며, ROLE_ADMIN 권한을 가진 사용자만 접근할 수 있습니다.

1. 관리자 기능 기반 및 보안 설정
 - AdminController 및 AdminService를 생성하여 관리자 기능 로직을 분리.
 - SecurityConfig에 /api/admin/** 경로에 대한 접근 규칙을 추가하여, ADMIN 역할을 가진 사용자만 접근할 수 있도록 전체 API 보안 강화.
 - 개발 환경(dev 프로필)에서 애플리케이션 시작 시, 테스트용 관리자 계정과 프로필을 자동으로 생성하는 AdminInitializer를 추가하여 개발 편의성 증대.

2. 사용자 관리 기능
 - 사용자 목록 조회 및 검색 API 추가 (GET /api/admin/members)
    - memberId를 포함한 관리자 전용 응답 DTO(MemberInfoForAdminResponse) 생성.
    - 관리자가 페이징 처리된 사용자 목록을 조회할 수 있는 기능 제공.
 - 사용자 역할 변경 API 추가 (PATCH /api/admin/members/{memberId}/role)
    - Member 엔티티에 updateRole() 메서드를 추가.
    - 관리자가 특정 사용자의 memberId를 이용해 역할을 USER 또는 ADMIN으로 변경할 수 있는 기능 제공.
    - @PreAuthorize("hasRole('ADMIN')")을 통해 API 레벨에서 이중으로 권한을 검사.

3. 모집글(Project) 관리 기능
 - 모집글 통합 조회 및 검색 API 추가 (GET /api/admin/projects)
    - Soft Delete된 게시글까지 모두 조회할 수 있도록 @Where 어노테이션을 우회하는 Querydsl 검색 로직(searchProjectsForAdmin) 구현.
    - 삭제 여부(isDeleted) 필드를 포함하는 관리자 전용 응답 DTO(ProjectInfoForAdminResponse) 생성.
    - 기존의 모든 필터, 검색, 정렬 기능을 관리자 조회 API에서도 동일하게 사용 가능.
 - 모집글 삭제 처리 API 추가 (DELETE /api/admin/projects/{projectId})
    - 관리자가 projectId를 이용해 특정 모집글을 Soft Delete 처리할 수 있는 기능 제공.
    - 실제 데이터는 보존하되, 사용자에게는 노출되지 않도록 isDeleted 상태만 변경.

4. 유저수 제공 기능