### PR TITLE
[feat] findByIncludeDeleted 메서드 네이티브쿼리 적용 (#6)

### DIFF
--- a/Gathering_be/src/main/java/com/Gathering_be/repository/ProjectRepository.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/repository/ProjectRepository.java
@@ -16,6 +16,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
     Page<Project> findAllByProfileNickname(String nickname, Pageable pageable);
     Page<Project> findAllByProfileNicknameAndIsClosed(String nickname, boolean isClosed, Pageable pageable);
     List<Project> findAllByDeadlineBeforeAndIsClosedFalse(LocalDateTime now);
-    @Query("SELECT p FROM Project WHERE p.id = :id")
+    @Query(value = "SELECT * FROM project WHERE id = :id", nativeQuery = true)
     Optional<Project> findByIdIncludeDeleted(@Param("id") Long id);
 }


### PR DESCRIPTION
[feat] findByIncludeDeleted 메서드 네이티브쿼리 적용 (#6)

Project 엔티티에 붙어있는 @Where(clause = "is_deleted = false") 글로벌 필터 때문에 오류 발생.
Hibernate가 쿼리를 처리할 때, 이 글로벌 필터와 @Query에 명시된 쿼리를 함께 처리하려다가 내부적으로 혼란이 발생하여 Project 엔티티의 별칭인 p를 제대로 인식하지 못함

네이티브 쿼리를 적용해, 쿼리를 직접적으로 전달