### PR TITLE
Be/feat/admin

### DIFF
--- a/Gathering_be/src/main/java/com/Gathering_be/domain/Profile.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/domain/Profile.java
@@ -140,9 +140,16 @@ public class Profile extends BaseTimeEntity {
         pendingApplications++;
     }
 
-    public void removePendingApplication() {
+    public void removeApplication(ApplyStatus status) {
         totalApplications--;
-        pendingApplications--;
+
+        if (status == ApplyStatus.PENDING) {
+            pendingApplications--;
+        } else if (status == ApplyStatus.APPROVED) {
+            approvedApplications--;
+        } else if (status == ApplyStatus.REJECTED) {
+            rejectedApplications--;
+        }
     }
 
     public void updateApplicationStatus(ApplyStatus newStatus) {

--- a/Gathering_be/src/main/java/com/Gathering_be/domain/Project.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/domain/Project.java
@@ -21,7 +21,6 @@ import java.util.Set;
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Where(clause = "is_deleted = false")
 public class Project extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Gathering_be/src/main/java/com/Gathering_be/repository/ApplicationRepository.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/repository/ApplicationRepository.java
@@ -3,14 +3,12 @@ package com.Gathering_be.repository;
 import com.Gathering_be.domain.Application;
 import com.Gathering_be.domain.Project;
 import com.Gathering_be.global.enums.ApplyStatus;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
-    List<Application> findByProjectId(Long projectId);
+    List<Application> findAllByProjectId(Long projectId);
     List<Application> findAllByProjectAndStatus(Project project, ApplyStatus status);
     boolean existsByProjectId(Long projectId);
 }

--- a/Gathering_be/src/main/java/com/Gathering_be/repository/custom/ProjectRepositoryImpl.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/repository/custom/ProjectRepositoryImpl.java
@@ -37,6 +37,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                                                    SearchType searchType, String keyword) {
         // 공통 로직을 호출하여 기본 조건절 생성
         BooleanBuilder builder = createCommonWhereBuilder(position, techStacks, type, mode, isClosed, searchType, keyword);
+        builder.and(project.isDeleted.eq(false));
 
         // 쿼리 실행 로직 호출
         return executeQuery(builder, pageable);

--- a/Gathering_be/src/main/java/com/Gathering_be/service/AdminService.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/service/AdminService.java
@@ -86,7 +86,7 @@ public class AdminService {
         Set<String> recipientEmails = new HashSet<>();
 
         Profile authorProfile = project.getProfile();
-        recipientEmails.add(authorProfile.getMember().getEmail());
+        /*recipientEmails.add(authorProfile.getMember().getEmail());
 
         List<Application> applications = applicationRepository.findAllByProjectId(projectId);
 
@@ -100,7 +100,7 @@ public class AdminService {
         }
 
         emailService.sendProjectDeletionNotice(new ArrayList<>(recipientEmails));
-
+        */
         authorProfile.removeProject(project.isClosed());
         project.delete();
     }

--- a/Gathering_be/src/main/java/com/Gathering_be/service/AdminService.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.Gathering_be.service;
 
+import com.Gathering_be.domain.Application;
 import com.Gathering_be.domain.Member;
 import com.Gathering_be.domain.Profile;
 import com.Gathering_be.domain.Project;
@@ -10,6 +11,7 @@ import com.Gathering_be.exception.InvalidSortTypeException;
 import com.Gathering_be.exception.MemberNotFoundException;
 import com.Gathering_be.exception.ProjectNotFoundException;
 import com.Gathering_be.global.enums.*;
+import com.Gathering_be.repository.ApplicationRepository;
 import com.Gathering_be.repository.MemberRepository;
 import com.Gathering_be.repository.ProfileRepository;
 import com.Gathering_be.repository.ProjectRepository;
@@ -21,8 +23,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,6 +32,8 @@ public class AdminService {
     private final MemberRepository memberRepository;
     private final ProfileRepository profileRepository;
     private final ProjectRepository projectRepository;
+    private final ApplicationRepository applicationRepository;
+    private final EmailService emailService;
 
     public List<MemberInfoForAdminResponse> getMembers() {
         List<Profile> profiles = profileRepository.findAllWithMember();
@@ -76,11 +79,29 @@ public class AdminService {
     public void deleteProject(Long projectId) {
         Project project = getProjectByIdForUpdate(projectId);
 
-//        if (applicationRepository.existsByProjectId(projectId)){
-//            throw new ProjectHasApplicantsException();
-//        }
+        if (project.isDeleted()) {
+            return;
+        }
 
-        project.getProfile().removeProject(project.isClosed());
+        Set<String> recipientEmails = new HashSet<>();
+
+        Profile authorProfile = project.getProfile();
+        recipientEmails.add(authorProfile.getMember().getEmail());
+
+        List<Application> applications = applicationRepository.findAllByProjectId(projectId);
+
+        for (Application application : applications) {
+            Profile applicantProfile = application.getProfileFromSnapshot();
+
+            if (applicantProfile != null) {
+                recipientEmails.add(applicantProfile.getMember().getEmail());
+                applicantProfile.removeApplication(application.getStatus());
+            }
+        }
+
+        emailService.sendProjectDeletionNotice(new ArrayList<>(recipientEmails));
+
+        authorProfile.removeProject(project.isClosed());
         project.delete();
     }
 

--- a/Gathering_be/src/main/java/com/Gathering_be/service/ApplicationService.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/service/ApplicationService.java
@@ -72,7 +72,7 @@ public class ApplicationService {
             throw new UnauthorizedAccessException();
         }
 
-        return applicationRepository.findByProjectId(projectId)
+        return applicationRepository.findAllByProjectId(projectId)
                 .stream()
                 .map(app -> ApplicationResponse.from(app, s3Service))
                 .collect(Collectors.toList());
@@ -82,7 +82,7 @@ public class ApplicationService {
     public ApplicationResponse getMyApplicationByProjectId(Long projectId) {
         Long currentUserId = getCurrentUserId();
         Profile profile = getProfileByMemberId(currentUserId);
-        List<Application> applications = applicationRepository.findByProjectId(projectId);
+        List<Application> applications = applicationRepository.findAllByProjectId(projectId);
 
         Application myApp = applications.stream()
                 .filter(app -> app.getProfileFromSnapshot().getId().equals(profile.getId()))
@@ -164,7 +164,7 @@ public class ApplicationService {
             throw new ApplicationAlreadyProcessedException();
         }
 
-        profile.removePendingApplication();
+        profile.removeApplication(ApplyStatus.PENDING);
         applicationRepository.delete(application);
     }
 

--- a/Gathering_be/src/main/java/com/Gathering_be/service/EmailService.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/service/EmailService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class EmailService {
@@ -64,6 +66,20 @@ public class EmailService {
         String subject = "[Gathering] 새 지원서가 도착했습니다!";
 
         sendHtmlMail(to, subject, htmlContent);
+    }
+
+    public void sendProjectDeletionNotice(List<String> recipients) {
+        Context context = new Context();
+        //context.setVariable("projectTitle", projectTitle);
+        //context.setVariable("authorName", authorName);
+        context.setVariable("link", "https://www.gathering.work");
+
+        String htmlContent = templateEngine.process("notify", context);
+        String subject = "[Gathering] 삭제";
+
+        for (String to : recipients) {
+            sendHtmlMail(to, subject, htmlContent);
+        }
     }
 
     private void sendHtmlMail(String to, String subject, String htmlContent) {

--- a/Gathering_be/src/main/java/com/Gathering_be/service/ProjectService.java
+++ b/Gathering_be/src/main/java/com/Gathering_be/service/ProjectService.java
@@ -83,7 +83,7 @@ public class ProjectService {
 
     @Transactional
     public void deleteProject(Long projectId) {
-        Project project = getProjectByIdForUpdate(projectId);
+        Project project = getProjectById(projectId);
         validateMemberAccess(project);
 
         if (applicationRepository.existsByProjectId(projectId)){


### PR DESCRIPTION
1. applicationRepository 메서드 이름 변경 (통일성 유지)
2. 프로필 지원서 갯수 필드 변경 메서드 통일
3. 관리자가 모집글 삭제 시 메일 전송 기능 일부 구현
4. 삭제 기능 오류 수정
- Project 엔티티의 @Where  삭제.
- ProjectService 의 일반 이용자 전용 조회 메서드에 isDeleted=false 고정